### PR TITLE
Remove travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: required
-services:
-- docker
-script:
-- make test


### PR DESCRIPTION
Since we have a working github workflow, I don't think we need Travis anymore, but maybe @ialarmedalien kept it in for a reason.