### PR TITLE
Modify triggers and remove dockerdeploy in github workflow file

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,8 @@
 name: Relation Engine test and deploy
 on:
-  [push, pull_request]
+  push:
+    branches: [ develop, master ]
+  pull_request_target:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
@@ -17,33 +19,35 @@ jobs:
         docker-compose run re_api sh scripts/run_tests.sh
         docker-compose down --remove-orphans
 
-  docker_build_and_push:
-    runs-on: ubuntu-latest
-    needs: run_tests
-    if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && github.event_name == 'push' && !contains(github.event.head_commit.message, 'skip_docker_build')
-    steps:
-    - name: checkout git repo
-      uses: actions/checkout@v2
 
-    - name: copy VERSION to TAG_NAME
-      shell: bash
-      run: |
-        mkdir -p .target
-        cp VERSION .target/TAG_NAME
-
-    - name: set env vars
-      shell: bash
-      run: |
-        echo "DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
-        echo "BRANCH=$(git symbolic-ref --short HEAD)" >> $GITHUB_ENV
-        echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-    - name: build and push to dockerhub
-      uses: opspresso/action-docker@master
-      with:
-        args: --docker
-      env:
-        USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKERFILE: "Dockerfile"
-        IMAGE_NAME: "kbase/relation_engine_api"
+#   docker_build_and_push:
+#     runs-on: ubuntu-latest
+#     needs: run_tests
+#     if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && github.event_name == 'push' && !contains(github.event.head_commit.message, 'skip_docker_build')
+#     steps:
+#     - name: checkout git repo
+#       uses: actions/checkout@v2
+#
+#     - name: copy VERSION to TAG_NAME
+#       shell: bash
+#       run: |
+#         mkdir -p .target
+#         cp VERSION .target/TAG_NAME
+#
+#     - name: set env vars
+#       shell: bash
+#       run: |
+#         echo "DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
+#         echo "BRANCH=$(git symbolic-ref --short HEAD)" >> $GITHUB_ENV
+#         echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+#
+#     - name: build and push to dockerhub
+#       uses: opspresso/action-docker@master
+#       with:
+#         args: --docker
+#       env:
+#         USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#   [push, pull_request]
+#         PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#         DOCKERFILE: "Dockerfile"
+#         IMAGE_NAME: "kbase/relation_engine_api"


### PR DESCRIPTION
Most of our PRs are not updates to the API, so I don't think we need to automatically run this docker deploy code on every push to `develop`.

I like to explicitly run the `scripts/docker_deploy` command to actually update the image on docker hub when needed. I often find the control this provides to be very useful.

Also, if we run on the `pull_request_target` event, then people will be able to use their secret tokens from their forks. We were also running the workflow twice on any PR, as it was triggering on both push and PR. So I made it trigger on push only for develop and master, same as what we're doing in index_runner.