### PR TITLE
Update edge_type.yaml to align with exascale_data repo

### DIFF
--- a/spec/datasets/djornl/edge_type.yaml
+++ b/spec/datasets/djornl/edge_type.yaml
@@ -52,3 +52,43 @@ oneOf:
     title: ATRM TF to Target LitCurated 01082020 TranscriptionFactorToGene
     description: Contains literature mined and manually curated TF regulatory interactions for A.thaliana from 1701 TFFs from PlantTFDB 2.0 and 4663 TF-associated interactions. These were manually filtered (e.g. FPs, PPI interactions removed). They then added some from other sources. Downloaded from http://atrm.cbi.pku.edu.cn/download.php
 
+  - const      : AT-UU-GO-03-AA-01
+    title      : GO
+    description: GeneA connects to GeneB if the two genes have semantically similar GO terms (with a similarity score > 0). This network is used to evaluate other networks for biological functional content.
+
+  - const      : AT-UU-KS-00-AA-01
+    title      : Knockout Similarity
+    description: GeneA connects to GeneB if the phenotypic effect of knocking out GeneA is similar to the phenotypic effect of knocking out GeneB. Similarity is based on Phenotype Ontology semantic similarity.
+
+  - const      : AT-UU-PX-01-AA-01
+    title      : PEN-Diversity
+    description: GeneA connects to GeneB if the expression vector of GeneA is an important predictor of the expression vector of GeneB in an iRF model, where all other genes’ expression are included as covariates. The iRF model is a feature-selection version of Random Forest.
+
+  - const      : AT-UU-GA-01-AA-01
+    title      : Coex Gene-Atlas
+    description: Coexpression network obtained from AtGenie.org. It uses expression array data from multiple tissues to calculate the correlation between genes.
+
+  - const      : AT-UU-PP-00-AA-01
+    title      : PPI-6merged
+    description: "GeneA connects to GeneB if their protein products have been shown to bind to interact with each other, typically through experimental evidence. The PPI-6merged network is the union of 6 different A.thaliana PPI networks: AraNet2 LC, AraNet2 HT, AraPPInet2 0.60, BIOGRID 4.3.194 physical, AtPIN, Mentha. These 6 were all relatively high scoring with GOintersect. StringDB scored badly so was not included"
+
+  - const      : AT-UU-RE-00-AA-01
+    title      : Regulation-ATRM
+    description: GeneA connects to GeneB if GeneA is a Transcription Factor (TF) that is shown to interact with GeneB (which may or may not be a TF). This dataset contains literature mined and manually curated TF regulatory interactions for A.thaliana. Started from 1701 TFs from PlantTFDB 2.0 and retrieved 4663 TF-associated interactions. These were manually filtered (e.g. FPs, PPI interactions removed). They then added some from other sources. Final result is 1431 confirmed TF regulatory interactions, of which 637 are TF-TF.
+
+  - const      : AT-UU-RP-03-AA-01
+    title      : Regulation-Plantregmap
+    description: This network contains computationally predicted TF-Target relationships based on motifs, binding sites, ChipSeq data
+
+  - const      : AT-UU-DU-07-AA-01
+    title      : CoEvolution-DUO
+    description: GeneA connects to GeneB if a SNP in GeneA is correlated with a SNP in GeneB using the DUO metric (cite). SNP data is from the full 1001 Genomes.
+
+  - const      : AT-UU-CD-00-AA-01
+    title      : CoDomain
+    description: GeneA connects to GeneB if they share one or more common protein domains. Network was obtained from AraNet2.
+
+  - const      : AT-UU-RX-00-AA-01
+    title      : Metabolic-AraCyc
+    description: GeneA connects to GeneB if they are both enzymatic and are linked by a common substrate or product. E.g. RXNA (GeneA) → Compound1 → RXNB (GeneB). Here GeneA connects to GeneB due to Compound1.
+


### PR DESCRIPTION
- [ ] I updated the README.md docs to reflect this change.

For changes to the codebase:

- [ ] I have written tests to cover this change.
- [x] This is not a breaking API change OR
- [ ] This is a breaking API change and I have incremented the API version and added a summary to CHANGELOG.md.


Relation engine:

```
 $ RES_ROOT_DATA_PATH=../exascale_data/prerelease/ python -m importers.djornl.parser --dry-run
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-KS-00-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-GA-01-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-PP-00-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-RE-00-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-RP-03-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-CD-00-AA-01.tsv
Parsing edge file /Users/m8z/src/exascale_data/prerelease/edge_data/AT-UU-RX-00-AA-01.tsv
Parsing node file /Users/m8z/src/exascale_data/prerelease/aranet2-aragwas-MERGED-AMW-v2_091319_nodeTable.csv
Parsing cluster file /Users/m8z/src/exascale_data/prerelease/cluster_data/out.aranetv2_subnet_AT-CX_top10percent_anno_AF_082919.abc.I2_named.tsv
Parsing cluster file /Users/m8z/src/exascale_data/prerelease/cluster_data/out.aranetv2_subnet_AT-CX_top10percent_anno_AF_082919.abc.I4_named.tsv
Parsing cluster file /Users/m8z/src/exascale_data/prerelease/cluster_data/out.aranetv2_subnet_AT-CX_top10percent_anno_AF_082919.abc.I6_named.tsv

 26745 Total nodes
711040 Total edges
 25108 Nodes in edge
---
Node Types
  5069 No type
 21669 gene
     7 pheno
---
Edge Types
 94952 AT-UU-KS-00-AA-01
 82900 AT-UU-GA-01-AA-01
317441 AT-UU-PP-00-AA-01
  1359 AT-UU-RE-00-AA-01
167851 AT-UU-RP-03-AA-01
 25000 AT-UU-CD-00-AA-01
 21537 AT-UU-RX-00-AA-01
---
Node data available
  5069 Key only
     0 Cluster
 21676 Full
---
     0 Errors
```