### PR TITLE
updated edge_type.yaml to match data repo

### DIFF
--- a/spec/datasets/djornl/edge_type.yaml
+++ b/spec/datasets/djornl/edge_type.yaml
@@ -52,7 +52,7 @@ oneOf:
     title: ATRM TF to Target LitCurated 01082020 TranscriptionFactorToGene
     description: Contains literature mined and manually curated TF regulatory interactions for A.thaliana from 1701 TFFs from PlantTFDB 2.0 and 4663 TF-associated interactions. These were manually filtered (e.g. FPs, PPI interactions removed). They then added some from other sources. Downloaded from http://atrm.cbi.pku.edu.cn/download.php
 
-  - const      : AT-UU-GO-03-AA-01
+  - const      : AT-UU-GO-05-AA-01
     title      : GO
     description: GeneA connects to GeneB if the two genes have semantically similar GO terms (with a similarity score > 0). This network is used to evaluate other networks for biological functional content.
 
@@ -80,9 +80,9 @@ oneOf:
     title      : Regulation-Plantregmap
     description: This network contains computationally predicted TF-Target relationships based on motifs, binding sites, ChipSeq data
 
-  - const      : AT-UU-DU-07-AA-01
+  - const      : AT-UU-DU-67-AA-01
     title      : CoEvolution-DUO
-    description: GeneA connects to GeneB if a SNP in GeneA is correlated with a SNP in GeneB using the DUO metric (cite). SNP data is from the full 1001 Genomes.
+    description: GeneA connects to GeneB if a SNP in GeneA is correlated with a SNP in GeneB using the DUO metric (https://doi.org/10.1101/2020.01.28.923730). SNP data is from the full 1001 Genomes.
 
   - const      : AT-UU-CD-00-AA-01
     title      : CoDomain
@@ -91,3 +91,7 @@ oneOf:
   - const      : AT-UU-RX-00-AA-01
     title      : Metabolic-AraCyc
     description: GeneA connects to GeneB if they are both enzymatic and are linked by a common substrate or product. E.g. RXNA (GeneA) → Compound1 → RXNB (GeneB). Here GeneA connects to GeneB due to Compound1.
+
+  - const      : AT-UU-PY-01-LF-01
+    title      : Predictive CG Methylation
+    description: GeneA connects to GeneB if the CG methylation vector of GeneA is an important predictor of the CG methylation vector of GeneB in an iRF model, where all other genes' CG methylation states are included as covariates. The iRF model is an expansion on Random Forest, a feature selection model.


### PR DESCRIPTION
- [ ] I updated the README.md docs to reflect this change.

For changes to the codebase:

- [ ] I have written tests to cover this change.
- [X] This is not a breaking API change OR
- [ ] This is a breaking API change and I have incremented the API version and added a summary to CHANGELOG.md.

Relation engine:

```
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-GO-05-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-KS-00-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-PX-01-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-GA-01-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-PP-00-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-RE-00-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-RP-03-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-DU-67-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-CD-00-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-RX-00-AA-01.tsv
Parsing edge file <...>/exascale_data_repo/prerelease/edge_data/AT-UU-PY-01-LF-01.tsv
Parsing node file <...>/exascale_data_repo/prerelease/Ath_master_annotation_v01.txt

  39851 Total nodes
1637771 Total edges
  26782 Nodes in edge
---
Node Types
  39851 No type
---
Edge Types
 696523 AT-UU-GO-05-AA-01
  94952 AT-UU-KS-00-AA-01
 145407 AT-UU-PX-01-AA-01
  82900 AT-UU-GA-01-AA-01
 317441 AT-UU-PP-00-AA-01
   1359 AT-UU-RE-00-AA-01
 167851 AT-UU-RP-03-AA-01
  13514 AT-UU-DU-67-AA-01
  25000 AT-UU-CD-00-AA-01
  21537 AT-UU-RX-00-AA-01
  71287 AT-UU-PY-01-LF-01
---
Node data available
     32 Key only
      0 Cluster
  39819 Full
---
      0 Errors
```