### PR TITLE
Run shared workflow

### DIFF
--- a/.github/workflows/run_shared_workflow.yaml
+++ b/.github/workflows/run_shared_workflow.yaml
@@ -1,0 +1,14 @@
+---
+name: Run shared workflow
+on:
+  pull_request:
+    branches:
+    - main
+    types:
+    - opened
+    - synchronize
+    - ready_for_review
+
+jobs:
+  run_important_job:
+    uses: kbase/.github/.github/workflows/shared_workflow.yaml


### PR DESCRIPTION
Adding a throwaway workflow to demonstrate running workflows from a shared repo

This is a temporary addition and will be removed soon.