### PR TITLE
Remove unnecessary push events

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,13 @@
 name: Relation Engine test and deploy
 on:
-  [push, pull_request]
+  pull_request:
+    branches:
+    - develop
+    types:
+    - opened
+    - synchronize
+    - ready_for_review
+
 jobs:
   run_tests:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- github actions only run on `pull_request`, no longer on `push`
+
 ## [0.0.19] - 2022-05-02
 ### Added
 - github actions to build `develop`, `pr-x` and released version (e.g. `1.2.3`) Tags


### PR DESCRIPTION
Remove the unnecessary run of GHA on push events; now they only run on pull

- [x] I updated the README.md docs to reflect this change.

For changes to the codebase:

- [ ] I have written tests to cover this change.
- [x] This is not a breaking API change OR
- [ ] This is a breaking API change and I have incremented the API version and added a summary to CHANGELOG.md.
