### PR TITLE
Update start_server.sh

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -11,7 +11,6 @@ python -m relation_engine_server.utils.wait_for services
 python -m relation_engine_server.utils.pull_spec
 
 gunicorn \
-  --worker-class gevent \
   --timeout 1800 \
   --workers $workers \
   --bind :5000 \


### PR DESCRIPTION
Switch from gevent to default for gunicorn.  We seem to be hitting errors with gevent.


- [ ] I updated the README.md docs to reflect this change.

For changes to the codebase:

- [ ] I have written tests to cover this change.
- [ ] This is not a breaking API change OR
- [ ] This is a breaking API change and I have incremented the API version and added a summary to CHANGELOG.md.
