### PR TITLE
Fix integration test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ The CI service is available in the `relationapi` service
 * Merge from Develop to Main
 * Draft a release using semantic versioning (e.g 1.2.3) by creating a tag with the target of Main
 * Ensure release notes are updated manually and/or by AutoGenerate Release Notes
+
+## Testing
+
+To run tests:
+```
+make test
+```

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -16,8 +16,10 @@ sh /app/scripts/start_server.sh &
 coverage erase
 # spec validation
 python -m spec.validate
+# wait for the RE service to be up so integration tests can pass
+python -m relation_engine_server.utils.wait_for api
 # run importer/, relation_engine_server/, and spec/ tests
 coverage run --branch -m pytest
-# RE client tests
+# RE client tests - seemss like these tests were already run in the line above, why run them again?
 PYTHONPATH=client_src python -m pytest client_src/test
 coverage html --omit=*/test_*


### PR DESCRIPTION
The tests were starting before the RE API was up. I hypothesize this explains
the 1 pass / 1 fail pattern - the first test would fail because the server
wasn't up, and the step that takes the server down wouldn't run. The next set
of tests would pass, and take the server down, and so on and so forth.

Closes #105 

- [n/a] I updated the README.md docs to reflect this change.

For changes to the codebase:

- [n/a] I have written tests to cover this change.
- [x] This is not a breaking API change OR
- [ ] This is a breaking API change and I have incremented the API version and added a summary to CHANGELOG.md.
